### PR TITLE
Change error handling

### DIFF
--- a/src/TestWorkers-Connector/TWAbstractConnected.class.st
+++ b/src/TestWorkers-Connector/TWAbstractConnected.class.st
@@ -104,19 +104,12 @@ TWAbstractConnected >> processMessage: aStampMessageFrame [
 
 	| message |
 	
-	[  
-		message := FLMaterializer materializeFromByteArray: aStampMessageFrame body.
-		message messageFrame: aStampMessageFrame.
-		message execute: self.
-		((aStampMessageFrame headerAt: 'subscription') includesSubstring: '/temp-queue/') 
-			ifFalse: [ 
-				connection write: aStampMessageFrame ackFrame ]. 
-	]	onErrorDo: [:e | | nackFrame |
-			nackFrame := aStampMessageFrame nackFrame.
-			connection write: nackFrame.
-			e debug ].
-	
-	
+	message := FLMaterializer materializeFromByteArray: aStampMessageFrame body.
+	message messageFrame: aStampMessageFrame.
+	message execute: self.
+	((aStampMessageFrame headerAt: 'subscription') includesSubstring: '/temp-queue/') 
+		ifFalse: [ 
+			connection write: aStampMessageFrame ackFrame ]
 ]
 
 { #category : #configuration }
@@ -135,13 +128,23 @@ TWAbstractConnected >> processPriority [
 TWAbstractConnected >> processRequest [
 
 	| msg |
-
-	[[msg := connection readMessage.
-	 self processMessage: msg] 
-		on: ConnectionTimedOut , ZnIncomplete do: [ ]]
-		on: Error do:[:e | 
-			e debug ].
-	
+	[
+	[
+	[msg := connection readMessage.
+	self processMessage: msg] on: ZnIncomplete
+		do: []]
+		on: NetworkError
+		do:
+			[:e |
+			| nackFrame |
+			[connection isConnected] whileFalse: [self doConnect].
+			listenerProcess isActiveProcess ifFalse: [self startListener].
+			msg
+				ifNotNil:
+					[nackFrame := msg nackFrame.
+					[connection write: nackFrame] onErrorDo: []]]]
+		on: Error
+		do: []
 ]
 
 { #category : #configuration }


### PR DESCRIPTION
Hello there

This PR tries to solve https://github.com/tesonep/pharo-testWorkers/issues/13

Feel free to improve or give me suggestions, I don't know if it was the best thing to do when getting a network error

Error handling responsibility has moved to `TWAbstractConnected >> processRequest`, I improved the behavior in case of NetworkError

Now when a runner has a connection error, it restarts by itself

Issue I had when testing: after 7 hours of running tests, all queues were suddenly removed from RabbitMQ so tests stopped, I have no idea why it happened and I don't know if it's related to my changes