### PR TITLE
Improved stability using more aggressive error handling

### DIFF
--- a/src/TestWorkers-Client/TWClient.class.st
+++ b/src/TestWorkers-Client/TWClient.class.st
@@ -142,8 +142,9 @@ TWClient >> runSingleTest: aSingleTest [
 		yourself.
 		
 	requests at: request uuid asString put: request.
-		
-	request sendOn: connection
+	
+	"RabbitMQ likes to close the connection. This ensures we retry until we are able to connect again."
+	self ensureNetworkSuccess: [ request sendOn: connection ]
 
 		
 ]
@@ -158,8 +159,9 @@ TWClient >> runTestClass: aTestCase [
 		yourself.
 		
 	requests at: request uuid asString put: request.
-		
-	request sendOn: connection
+	
+	"RabbitMQ likes to close the connection. This ensures we retry until we are able to connect again."
+	self ensureNetworkSuccess: [ request sendOn: connection ]
 
 	
 ]

--- a/src/TestWorkers-Connector/TWAbstractConnected.class.st
+++ b/src/TestWorkers-Connector/TWAbstractConnected.class.st
@@ -75,8 +75,35 @@ TWAbstractConnected >> doConnect [
 
 { #category : #operations }
 TWAbstractConnected >> ensureConnected [
+	"Ensure the connection is established.
+	Keep in mind that this can itself cause an network or stamp error."
 
 	[ connection isConnected ] whileFalse: [ self doConnect ]
+]
+
+{ #category : #operations }
+TWAbstractConnected >> ensureNetworkSuccess: aBlock [
+
+	| block |
+	"Run the block until it succeeds without a network error, or we get any other error.
+	Start by trying three times, and then try once every second."
+
+	block := [ 
+		[ [ 
+		self ensureConnected.
+		^ aBlock value ]
+			on: StampError
+			do: [ :e | self traceError: e ] ]
+			on: NetworkError
+			do: [ :e | self traceError: e ]
+	].
+
+	1 to: 3 do: [ :i | block value ].
+
+	[
+	(Delay forSeconds: 1) wait.
+	block value ] repeat
+
 ]
 
 { #category : #operations }
@@ -109,16 +136,23 @@ TWAbstractConnected >> password [
 
 { #category : #processing }
 TWAbstractConnected >> processMessage: aStampMessageFrame [
-
 	| message |
-	"We ACK the message as soon as we get it"
-	((aStampMessageFrame headerAt: 'subscription') includesSubstring: '/temp-queue/') 
-		ifFalse: [ 
-			connection write: aStampMessageFrame ackFrame ].
-
+	
+	[
 	message := FLMaterializer materializeFromByteArray: aStampMessageFrame body.
 	message messageFrame: aStampMessageFrame.
-	message execute: self.
+
+	"We ACK the message as soon as we get it"
+	((aStampMessageFrame headerAt: 'subscription')
+		includesSubstring: '/temp-queue/')
+			ifFalse: [ connection write: aStampMessageFrame ackFrame ] ]
+			onErrorDo: [ :e |
+				"If there is an error here, send a NACK if possible."
+				self traceError: e.
+				connection write: aStampMessageFrame nackFrame.
+				^self ].
+			
+	message execute: self
 
 ]
 
@@ -138,29 +172,13 @@ TWAbstractConnected >> processPriority [
 TWAbstractConnected >> processRequest [
 
 	| msg |
-	[ 
-	[ 
-	[
-	self ensureConnected.
-	msg := connection readMessage.
-	self processMessage: msg ]
-		on: ZnIncomplete
-		do: [ :e | self traceError: e ] ]
-		on: NetworkError
-		do: [ :e | 
-			| nackFrame |
+	[msg := connection readMessage.
+	self processMessage: msg]
+		onErrorDo:
+			[:e |
+			self traceError: e.
 			self ensureConnected.
-			listenerProcess isActiveProcess ifFalse: [ self startListener ].
-			self traceError: e
-
-			" If the Msg is ACK when received, we don't need to NACK it on an error. It has been already removed from the queue.
-			msg
-				ifNotNil:
-					[nackFrame := msg nackFrame.
-					 nackFrame requeue: false.
-					[connection write: nackFrame] onErrorDo: [:x | self traceError: x]]" ] ]
-		on: Error
-		do: [ :e | self traceError: e ]
+			listenerProcess isActiveProcess ifFalse: [ self startListener ] ]
 ]
 
 { #category : #configuration }
@@ -192,13 +210,13 @@ TWAbstractConnected >> start [
 
 { #category : #operations }
 TWAbstractConnected >> startListener [
-	
-	listenerProcess := [ 
-		[ self ensureConnected.
-		  connection isConnected
-			ifTrue: [ self processRequest ] ] repeat ] 
-		forkAt: self processPriority 
-		named: self processName.
+
+	listenerProcess :=
+			[ 
+			[ self ensureNetworkSuccess: [ self processRequest ] ]
+				repeat]
+				forkAt: self processPriority
+				named: self processName
 ]
 
 { #category : #operations }

--- a/src/TestWorkers-Connector/TWAbstractConnected.class.st
+++ b/src/TestWorkers-Connector/TWAbstractConnected.class.st
@@ -103,7 +103,8 @@ TWAbstractConnected >> ensureNetworkSuccess: aBlock [
 	1 to: 3 do: [ :i | block value ].
 
 	[
-	connection close. "Resolves some problems."
+	[ connection close "Resolves some problems." ]
+		onErrorDo: [ "Ignore, we want it closed." ].
 	(Delay forSeconds: 1) wait.
 	block value ] repeat
 

--- a/src/TestWorkers-Connector/TWAbstractConnected.class.st
+++ b/src/TestWorkers-Connector/TWAbstractConnected.class.st
@@ -74,6 +74,12 @@ TWAbstractConnected >> doConnect [
 ]
 
 { #category : #operations }
+TWAbstractConnected >> ensureConnected [
+
+	[ connection isConnected ] whileFalse: [ self doConnect ]
+]
+
+{ #category : #operations }
 TWAbstractConnected >> ensureStart [
 
 	(connection isConnected and: [ listenerProcess isTerminating not ])
@@ -132,27 +138,29 @@ TWAbstractConnected >> processPriority [
 TWAbstractConnected >> processRequest [
 
 	| msg |
+	[ 
+	[ 
 	[
-	[
-	[msg := connection readMessage.
-	self processMessage: msg] on: ZnIncomplete
-		do: [:e | self traceError: e]]
+	self ensureConnected.
+	msg := connection readMessage.
+	self processMessage: msg ]
+		on: ZnIncomplete
+		do: [ :e | self traceError: e ] ]
 		on: NetworkError
-		do:
-			[:e |
+		do: [ :e | 
 			| nackFrame |
-			[connection isConnected] whileFalse: [self doConnect].
-			listenerProcess isActiveProcess ifFalse: [self startListener].
-			self traceError: e.
-			
+			self ensureConnected.
+			listenerProcess isActiveProcess ifFalse: [ self startListener ].
+			self traceError: e
+
 			" If the Msg is ACK when received, we don't need to NACK it on an error. It has been already removed from the queue.
 			msg
 				ifNotNil:
 					[nackFrame := msg nackFrame.
 					 nackFrame requeue: false.
-					[connection write: nackFrame] onErrorDo: [:x | self traceError: x]]"]]
+					[connection write: nackFrame] onErrorDo: [:x | self traceError: x]]" ] ]
 		on: Error
-		do: [:e | self traceError: e]
+		do: [ :e | self traceError: e ]
 ]
 
 { #category : #configuration }
@@ -186,8 +194,7 @@ TWAbstractConnected >> start [
 TWAbstractConnected >> startListener [
 	
 	listenerProcess := [ 
-		[ connection isConnected 
-			ifFalse: [ self doConnect ].
+		[ self ensureConnected.
 		  connection isConnected
 			ifTrue: [ self processRequest ] ] repeat ] 
 		forkAt: self processPriority 

--- a/src/TestWorkers-Connector/TWAbstractConnected.class.st
+++ b/src/TestWorkers-Connector/TWAbstractConnected.class.st
@@ -103,6 +103,7 @@ TWAbstractConnected >> ensureNetworkSuccess: aBlock [
 	1 to: 3 do: [ :i | block value ].
 
 	[
+	connection close. "Resolves some problems."
 	(Delay forSeconds: 1) wait.
 	block value ] repeat
 

--- a/src/TestWorkers-Connector/TWAbstractConnected.class.st
+++ b/src/TestWorkers-Connector/TWAbstractConnected.class.st
@@ -89,10 +89,12 @@ TWAbstractConnected >> ensureNetworkSuccess: aBlock [
 	Start by trying three times, and then try once every second."
 
 	block := [ 
-		[ [ 
+		[ [ [ 
 		self ensureConnected.
 		^ aBlock value ]
 			on: StampError
+			do: [ :e | self traceError: e ] ]
+			on: ZnIncomplete
 			do: [ :e | self traceError: e ] ]
 			on: NetworkError
 			do: [ :e | self traceError: e ]

--- a/src/TestWorkers-Worker/TWRunner.class.st
+++ b/src/TestWorkers-Worker/TWRunner.class.st
@@ -70,15 +70,17 @@ TWRunner >> executionResponseOf: aTWMessage withResult: testResults [
 TWRunner >> handleMaybeDuplicateOf: aTWMessage answering: aValuable [
 
 	| answer |
-
-	messagesSent
-		at: aTWMessage uuid
-		ifPresent: [ :message | ^ message sendOn: connection ].
+	messagesSent at: aTWMessage uuid ifPresent: [ :message | 
+		self ensureNetworkSuccess: [
+			^ message sendOn: connection ] ].
 
 	answer := aValuable value.
-	
-	self ensureConnected.
-	answer sendOn: connection.
+
+	"Try to send the message until we succeed.
+	There is no point in continuing if we have a network error.
+	We will probably not be able to get the next message anyways and
+	losing the executed message is unacceptable."
+	self ensureNetworkSuccess: [ answer sendOn: connection ].
 	messagesSent at: aTWMessage uuid put: answer
 ]
 
@@ -97,7 +99,12 @@ TWRunner >> processName [
 { #category : #operations }
 TWRunner >> runTestMessage: aTWMessage [
 
-	self handleMaybeDuplicateOf: aTWMessage answering: [ self doRunTestMessage: aTWMessage ]
+	connection close. "Disconnect because some tests might mess with the connection. This forces us to reconnect, but longer tests will lose the connection anyway."
+	[ self handleMaybeDuplicateOf: aTWMessage answering: [ self doRunTestMessage: aTWMessage ] ]
+		onErrorDo: [ :e |
+			"If there is an unhandled error, requeue the tests message."
+			self traceError: e.
+			self ensureNetworkSuccess: [ aTWMessage sendOn: connection ] ]
 
 ]
 

--- a/src/TestWorkers-Worker/TWRunner.class.st
+++ b/src/TestWorkers-Worker/TWRunner.class.st
@@ -76,9 +76,10 @@ TWRunner >> handleMaybeDuplicateOf: aTWMessage answering: aValuable [
 		ifPresent: [ :message | ^ message sendOn: connection ].
 
 	answer := aValuable value.
-
-	messagesSent at: aTWMessage uuid put: answer.
-	answer sendOn: connection
+	
+	self ensureConnected.
+	answer sendOn: connection.
+	messagesSent at: aTWMessage uuid put: answer
 ]
 
 { #category : #configuration }

--- a/src/TestWorkers-Worker/TWRunner.class.st
+++ b/src/TestWorkers-Worker/TWRunner.class.st
@@ -76,12 +76,13 @@ TWRunner >> handleMaybeDuplicateOf: aTWMessage answering: aValuable [
 
 	answer := aValuable value.
 
+	messagesSent at: aTWMessage uuid put: answer.
+	
 	"Try to send the message until we succeed.
 	There is no point in continuing if we have a network error.
 	We will probably not be able to get the next message anyways and
 	losing the executed message is unacceptable."
-	self ensureNetworkSuccess: [ answer sendOn: connection ].
-	messagesSent at: aTWMessage uuid put: answer
+	self ensureNetworkSuccess: [ answer sendOn: connection ]
 ]
 
 { #category : #configuration }
@@ -99,7 +100,8 @@ TWRunner >> processName [
 { #category : #operations }
 TWRunner >> runTestMessage: aTWMessage [
 
-	connection close. "Disconnect because some tests might mess with the connection. This forces us to reconnect, but longer tests will lose the connection anyway."
+	[ connection close "Disconnect because some tests might mess with the connection. This forces us to reconnect, but longer tests will lose the connection anyway." ]
+		onErrorDo: [ "Ignore, we want it closed." ].
 	[ self handleMaybeDuplicateOf: aTWMessage answering: [ self doRunTestMessage: aTWMessage ] ]
 		onErrorDo: [ :e |
 			"If there is an unhandled error, requeue the tests message."


### PR DESCRIPTION
We have a lot of network errors during the execution of the Lifeware test suite. These changes don't address the errors themselves, but they ensure that if a worker accepts a message, he will also send a result (unless he crashes during execution of the test). To do this, the #ensureNetworkSuccess method will try to send a message until it succeeds without a network error. Previously, the runner would lose the connection during the execution of the test and then the result message would not be sent and only when trying to get the next request would the runner reconnect, completely forgetting the message he should have sent.
There might be a better way to achieve this, but with these changes, we are able to more or less reliably execute all test automatically.