### PR TITLE
Replace defer: with cull: to call the updateBlock

### DIFF
--- a/src/TestWorkers-Client/TWClient.class.st
+++ b/src/TestWorkers-Client/TWClient.class.st
@@ -173,7 +173,7 @@ TWClient >> runTestExecutionError: aTWTestExecutionError [
 	
 	executionErrors add: aTWTestExecutionError.
 	
-	onUpdateBlock ifNotNil: [ UIManager default defer: onUpdateBlock ]
+	onUpdateBlock ifNotNil: [ onUpdateBlock cull: aTWTestExecutionError ]
 ]
 
 { #category : #operations }
@@ -184,7 +184,7 @@ TWClient >> runTestResponse: aTWTestResponse [
 	
 	testResult mergeWith: aTWTestResponse testResults.
 	
-	onUpdateBlock ifNotNil: [ UIManager default defer: onUpdateBlock ]
+	onUpdateBlock ifNotNil: [ onUpdateBlock cull: aTWTestResponse ]
 ]
 
 { #category : #changes }


### PR DESCRIPTION
Doesn't have any impact when running tests with DrTest, and it gives the possibility to give the block an argument