### PR TITLE
Implement headless start

### DIFF
--- a/src/TestWorkers-Watchdog/TWManagedWorkerInstance.class.st
+++ b/src/TestWorkers-Watchdog/TWManagedWorkerInstance.class.st
@@ -9,17 +9,19 @@ Class {
 		'watchdog',
 		'pid',
 		'host',
-		'directQueue'
+		'directQueue',
+		'headless'
 	],
 	#category : #'TestWorkers-Watchdog'
 }
 
 { #category : #'instance creation' }
-TWManagedWorkerInstance class >> directory: aPath on: aWatchdog [
+TWManagedWorkerInstance class >> directory: aPath on: aWatchdog headless: aBoolean [
 
 	^ self basicNew
 		path: aPath;
 		watchdog: aWatchdog;
+		headless: aBoolean;
 		initialize;
 		yourself.
 ]
@@ -32,6 +34,16 @@ TWManagedWorkerInstance >> directQueue [
 { #category : #accessing }
 TWManagedWorkerInstance >> directQueue: anObject [
 	directQueue := anObject
+]
+
+{ #category : #accessing }
+TWManagedWorkerInstance >> headless [
+	^ headless
+]
+
+{ #category : #accessing }
+TWManagedWorkerInstance >> headless: anObject [
+	headless := anObject
 ]
 
 { #category : #'private - operations' }
@@ -53,7 +65,7 @@ TWManagedWorkerInstance >> doStart [
 
 	TWSubprocessWrapper
 		runWithoutWaitingShellCommand:
-			Smalltalk vm fileName ,' ', ' "', self imageName 
+			Smalltalk vm fileName , (self headless ifTrue: [' --headless '] ifFalse: [' ']), ' "', self imageName 
 			, '" eval --no-quit "' , startScript , '"'
 		workingDirectory: path fullName 
 ]

--- a/src/TestWorkers-Watchdog/TWWatchdog.class.st
+++ b/src/TestWorkers-Watchdog/TWWatchdog.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'rootDirectory',
 		'instances',
-		'creationStrategy'
+		'creationStrategy',
+		'headless'
 	],
 	#category : #'TestWorkers-Watchdog'
 }
@@ -141,7 +142,8 @@ TWWatchdog >> numberOfInstances: anInteger [
 				             directory: (creationStrategy
 						              instanceDirectorWithRoot: self rootDirectory
 						              andImageIndex: anIndex)
-				             on: self ]
+				             on: self
+				             headless: self headless ]
 		             as: OrderedCollection
 ]
 
@@ -172,6 +174,16 @@ TWWatchdog >> rootDirectory [
 { #category : #accessing }
 TWWatchdog >> rootDirectory: anObject [
 	rootDirectory := anObject
+]
+
+{ #category : #accessing }
+TWWatchdog >> headless [
+	^ headless ifNil: [true]
+]
+
+{ #category : #accessing }
+TWWatchdog >> headless: anObject [
+	headless := anObject
 ]
 
 { #category : #operations }


### PR DESCRIPTION
Hello there

As we are less debugging than before, I implemented the possibility to start instances headless (default behavior now)

It's still possible to open windows using `TWWatchdog>>#headless:`